### PR TITLE
Add interactive map on home page

### DIFF
--- a/data/essen_wahlbezirke_2020.geojson
+++ b/data/essen_wahlbezirke_2020.geojson
@@ -1,0 +1,29 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {"name": "Bezirk 1", "link": "index.html"},
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[[7.0,51.45],[7.05,51.45],[7.05,51.48],[7.0,51.48],[7.0,51.45]]]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {"name": "Bezirk 2", "link": "index.html"},
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[[7.05,51.45],[7.1,51.45],[7.1,51.48],[7.05,51.48],[7.05,51.45]]]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {"name": "Bezirk 3", "link": "index.html"},
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[[7.0,51.48],[7.05,51.48],[7.05,51.51],[7.0,51.51],[7.0,51.48]]]
+      }
+    }
+  ]
+}

--- a/home.html
+++ b/home.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kommunalwahl Essen 2020</title>
+    <link rel="stylesheet" href="styles/main.css">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script src="scripts/home.js" defer></script>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/inter-ui/3.19.3/inter.css" rel="stylesheet">
+    <script src="scripts/main.js" defer></script>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/IBM-Plex-Serif/4.0.3/fonts/complete/woff/IBMPlexSerif-Regular.woff" rel="stylesheet">
+</head>
+<body>
+    <div class="container">
+        <header class="header">
+            <img src="medien/CDU-Gesamtlogo_transparent_RGB.png" alt="CDU Logo" class="logo">
+        </header>
+
+        <section class="profile-section">
+            <div class="profile-top">
+                <div class="profile-content">
+                    <h1 class="headline">Kommunalwahl 2020</h1>
+                    <div class="subline serif">Finden Sie Ihren Wahlkreis</div>
+                </div>
+                <svg class="bogen" viewBox="0 0 300 300" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M300 0V300H0C0 134.315 134.315 0 300 0Z" fill="white"/>
+                </svg>
+                <div class="cta-circle">
+                    BEIDE<br>STIMMEN<br>CDU
+                </div>
+            </div>
+        </section>
+
+        <section class="personal-section map-section">
+            <h2 class="section-title">Ihr Wahlbezirk</h2>
+            <div id="map" style="height: 400px;"></div>
+        </section>
+
+        <footer class="footer">
+            &copy; 2025 CDU Essen | <a href="#" style="color: var(--rhondorf-blau);">Impressum</a> | <a href="#" style="color: var(--rhondorf-blau);">Datenschutz</a>
+        </footer>
+    </div>
+
+    <div class="scroll-banner">
+        <div class="scroll-content">
+            Sonntag, 14.&nbsp;September – Wahltag von 8 bis 18&nbsp;Uhr sind die Wahllokale geöffnet oder jetzt schon per
+            <a href="URL_ZUR_BRIEFWAHL" class="banner-cta">Briefwahl</a>.
+        </div>
+    </div>
+</body>
+</html>

--- a/scripts/home.js
+++ b/scripts/home.js
@@ -1,0 +1,24 @@
+// Leaflet map initialisation
+var map = L.map('map').setView([51.455, 7.015], 12);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  attribution: '&copy; OpenStreetMap contributors'
+}).addTo(map);
+
+fetch('data/essen_wahlbezirke_2020.geojson')
+  .then(resp => resp.json())
+  .then(data => {
+    L.geoJSON(data, {
+      style: {
+        color: '#2d3c4b',
+        weight: 2,
+        fillColor: '#ffa600',
+        fillOpacity: 0.3
+      },
+      onEachFeature: function (feature, layer) {
+        layer.on('click', function () {
+          var link = feature.properties.link || '#';
+          layer.bindPopup('<strong>' + feature.properties.name + '</strong><br><a class="map-btn" href="' + link + '">Mehr erfahren</a>').openPopup();
+        });
+      }
+    }).addTo(map);
+  });

--- a/styles/main.css
+++ b/styles/main.css
@@ -790,3 +790,22 @@ body {
         grid-template-columns: 1fr;
     }
 }
+
+/* Map Section */
+.map-section #map {
+    border: 3px solid var(--rhondorf-blau);
+    border-radius: 8px;
+    height: 400px;
+}
+
+.map-btn {
+    display: inline-block;
+    margin-top: 8px;
+    background-color: var(--union-gold);
+    color: var(--rhondorf-blau);
+    padding: 6px 12px;
+    border-radius: 4px;
+    text-decoration: none;
+    font-weight: 700;
+}
+


### PR DESCRIPTION
## Summary
- design new `home.html` with CDU design language and embed Leaflet map
- style map section and call-to-action button
- implement map logic in `scripts/home.js`
- provide placeholder GeoJSON for Essen districts

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685801a55120832fa35430b030408739